### PR TITLE
fix(browserstack-service): raise CLI download connect timeout to avoid 10s undici abort (SDK-6152)

### DIFF
--- a/packages/wdio-browserstack-service/src/cli/cliUtils.ts
+++ b/packages/wdio-browserstack-service/src/cli/cliUtils.ts
@@ -43,6 +43,15 @@ const CLI_LOCK_POLL_MS = 1000
 const CLI_DOWNLOAD_TIMEOUT_MS = 5 * 60 * 1000
 const CLI_DOWNLOAD_TMP_PREFIX = 'downloaded_file_'
 const CLI_DOWNLOAD_TMP_SUFFIX = '.zip'
+// Connection-establishment timeout for CLI network calls (update_cli + binary
+// download). Node's global fetch hard-codes this at 10s and it is NOT overridable
+// via AbortSignal, so a slow TLS/TCP handshake in a constrained/containerised CI
+// network (e.g. Kubernetes pods) aborts with UND_ERR_CONNECT_TIMEOUT even though
+// the endpoint is healthy (SDK-6152). Routed through a custom undici dispatcher.
+// Overridable via env for tuning.
+const CLI_CONNECT_TIMEOUT_MS = Number(process.env.BROWSERSTACK_CLI_CONNECT_TIMEOUT_MS) || 60 * 1000
+const CLI_FETCH_MAX_ATTEMPTS = 3
+const CLI_FETCH_RETRY_BASE_DELAY_MS = 500
 
 export class CLIUtils {
     static automationFrameworkDetail = {}
@@ -199,7 +208,9 @@ export class CLIUtils {
             logger.debug(`Resolved binary path: ${finalBinaryPath}`)
             return finalBinaryPath
         } catch (err) {
-            logger.debug(
+            // Surface at warn (not debug) so a failed CLI setup is visible instead of
+            // the run exiting silently with no results (SDK-6152).
+            logger.warn(
                 `Error in setting up cli path directory, Exception: ${util.format(err)}`,
             )
         }
@@ -412,6 +423,39 @@ export class CLIUtils {
         }
     }
 
+    /**
+     * fetch wrapper for CLI network calls that (a) raises undici's connect timeout
+     * above the non-overridable 10s default of global fetch and (b) retries a few
+     * times with linear backoff on transient connection failures. Both are needed
+     * for reliability in constrained CI/containerised networks (SDK-6152).
+     */
+    static fetchWithRetry = async (
+        input: string,
+        init: RequestInit,
+        label: string,
+    ): Promise<Response> => {
+        let lastError: unknown
+        for (let attempt = 1; attempt <= CLI_FETCH_MAX_ATTEMPTS; attempt++) {
+            try {
+                return await fetch(input, init, { connectTimeoutMs: CLI_CONNECT_TIMEOUT_MS })
+            } catch (err) {
+                lastError = err
+                const reason =
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    (err as any)?.cause?.code || (err as any)?.code || (err as Error)?.message
+                logger.warn(
+                    `${label} attempt ${attempt}/${CLI_FETCH_MAX_ATTEMPTS} failed: ${reason}`,
+                )
+                if (attempt < CLI_FETCH_MAX_ATTEMPTS) {
+                    await new Promise((resolve) =>
+                        setTimeout(resolve, CLI_FETCH_RETRY_BASE_DELAY_MS * attempt),
+                    )
+                }
+            }
+        }
+        throw lastError
+    }
+
     static requestToUpdateCLI = async (
         queryParams: Record<string, string>,
         config: Options.Testrunner,
@@ -423,9 +467,10 @@ export class CLIUtils {
                 Authorization: `Basic ${Buffer.from(`${getBrowserStackUser(config)}:${getBrowserStackKey(config)}`).toString('base64')}`,
             },
         }
-        const response = await fetch(
+        const response = await this.fetchWithRetry(
             `${APIUtils.BROWSERSTACK_AUTOMATE_API_URL}/${UPDATED_CLI_ENDPOINT}?${params.toString()}`,
             requestInit,
+            'update_cli request',
         )
         const jsonResponse = await response.json()
         logger.debug(`response ${JSON.stringify(jsonResponse)}`)
@@ -662,9 +707,11 @@ export class CLIUtils {
                     )
                     let response: Response
                     try {
-                        response = await fetch(binDownloadUrl, {
-                            signal: abortController.signal,
-                        })
+                        response = await fetch(
+                            binDownloadUrl,
+                            { signal: abortController.signal },
+                            { connectTimeoutMs: CLI_CONNECT_TIMEOUT_MS },
+                        )
                     } finally {
                         clearTimeout(timeout)
                     }

--- a/packages/wdio-browserstack-service/src/fetchWrapper.ts
+++ b/packages/wdio-browserstack-service/src/fetchWrapper.ts
@@ -1,4 +1,4 @@
-import { fetch as undiciFetch, type RequestInit as UndiciRequestInit, ProxyAgent } from 'undici'
+import { fetch as undiciFetch, type RequestInit as UndiciRequestInit, ProxyAgent, Agent, type Dispatcher } from 'undici'
 
 export class ResponseError extends Error {
     public response: Response
@@ -8,15 +8,50 @@ export class ResponseError extends Error {
     }
 }
 
-export default async function fetchWrap(input: RequestInfo | URL, init?: RequestInit) {
-    const res = await _fetch(input, init)
+/**
+ * Extra options for {@link _fetch} that cannot be expressed through the standard
+ * `RequestInit`.
+ *
+ * `connectTimeoutMs` overrides undici's connection-establishment timeout. Node's
+ * global `fetch` hard-codes this to 10s and it is NOT overridable via
+ * `AbortSignal` (the signal only bounds the overall request, not the socket
+ * connect). In constrained/containerised CI networks (e.g. Kubernetes pods) a
+ * TLS/TCP handshake can legitimately take longer than 10s, so global fetch aborts
+ * with `UND_ERR_CONNECT_TIMEOUT` even though the endpoint is healthy. Supplying
+ * this option routes the request through a custom undici dispatcher with a larger
+ * connect timeout.
+ */
+export interface FetchOptions {
+    connectTimeoutMs?: number
+}
+
+// Dispatchers are relatively expensive to build and hold a connection pool, so we
+// cache one per (proxy, connectTimeout) combination instead of creating a new one
+// on every request.
+const dispatcherCache = new Map<string, Dispatcher>()
+
+function getDispatcher(proxyUrl: string | undefined, connectTimeoutMs: number): Dispatcher {
+    const key = `${proxyUrl ?? 'direct'}:${connectTimeoutMs}`
+    let dispatcher = dispatcherCache.get(key)
+    if (!dispatcher) {
+        dispatcher = proxyUrl
+            ? new ProxyAgent({ uri: proxyUrl, connect: { timeout: connectTimeoutMs } })
+            : new Agent({ connect: { timeout: connectTimeoutMs } })
+        dispatcherCache.set(key, dispatcher)
+    }
+    return dispatcher
+}
+
+export default async function fetchWrap(input: RequestInfo | URL, init?: RequestInit, options?: FetchOptions) {
+    const res = await _fetch(input, init, options)
     if (!res.ok) {
         throw new ResponseError(`Error response from server ${res.status}:  ${await res.text()}`, res)
     }
     return res
 }
 
-export function _fetch(input: RequestInfo | URL, init?: RequestInit) {
+export function _fetch(input: RequestInfo | URL, init?: RequestInit, options?: FetchOptions) {
+    const connectTimeoutMs = options?.connectTimeoutMs
     const proxyUrl = process.env.HTTP_PROXY || process.env.HTTPS_PROXY
     if (proxyUrl) {
         const noProxy = process.env.NO_PROXY && process.env.NO_PROXY.trim()
@@ -25,11 +60,23 @@ export function _fetch(input: RequestInfo | URL, init?: RequestInit) {
         const request = new Request(input)
         const url = new URL(request.url)
         if (!noProxy.some((str) => url.hostname.endsWith(str))) {
+            const dispatcher = connectTimeoutMs
+                ? getDispatcher(proxyUrl, connectTimeoutMs)
+                : new ProxyAgent(proxyUrl)
             return undiciFetch(
                 request.url,
-                { ...(init as UndiciRequestInit), dispatcher: new ProxyAgent(proxyUrl) },
+                { ...(init as UndiciRequestInit), dispatcher },
             ) as unknown as Promise<Response>
         }
+    }
+    // Without a proxy, global fetch's connect timeout is fixed at 10s and cannot be
+    // overridden, so when a caller needs a larger one we go through undici directly
+    // with a custom Agent. The default path is left untouched.
+    if (connectTimeoutMs) {
+        return undiciFetch(
+            new Request(input).url,
+            { ...(init as UndiciRequestInit), dispatcher: getDispatcher(undefined, connectTimeoutMs) },
+        ) as unknown as Promise<Response>
     }
     return fetch(input, init)
 }

--- a/packages/wdio-browserstack-service/tests/cli/cliUtils.test.ts
+++ b/packages/wdio-browserstack-service/tests/cli/cliUtils.test.ts
@@ -12,6 +12,16 @@ import { EVENTS as PerformanceEvents } from '../../src/instrumentation/performan
 import type { Options } from '@wdio/types'
 import type { BrowserstackConfig, BrowserstackOptions } from '../../src/types.js'
 import APIUtils from '../../src/cli/apiUtils.js'
+import type * as FetchWrapperModule from '../../src/fetchWrapper.js'
+
+// CLI network calls go through fetchWrapper._fetch (which uses a custom undici
+// dispatcher for the connect-timeout override), not the global fetch, so we mock
+// that boundary. Other fetchWrapper exports are preserved.
+const mockFetch = vi.hoisted(() => vi.fn())
+vi.mock('../../src/fetchWrapper.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof FetchWrapperModule>()
+    return { ...actual, _fetch: mockFetch }
+})
 
 const bstackLoggerSpy = vi.spyOn(bstackLogger.BStackLogger, 'logToFile')
 bstackLoggerSpy.mockImplementation(() => {})
@@ -523,7 +533,7 @@ describe('CLIUtils', () => {
             vi.resetAllMocks()
 
             // Mock fetch to return a mock response
-            global.fetch = vi.fn().mockResolvedValue({
+            mockFetch.mockResolvedValue({
                 json: vi.fn().mockResolvedValue({ status: 'success' })
             })
         })
@@ -539,30 +549,33 @@ describe('CLIUtils', () => {
             }
 
             const mockJsonResponse = { updated_cli_version: '2.0.0' }
-            global.fetch = vi.fn().mockResolvedValue({
+            mockFetch.mockResolvedValue({
                 json: vi.fn().mockResolvedValue(mockJsonResponse)
             })
 
             await CLIUtils.requestToUpdateCLI(queryParams, mockConfig)
 
-            expect(global.fetch).toHaveBeenCalledWith(
+            expect(mockFetch).toHaveBeenCalledWith(
                 expect.stringContaining('param1=value1'),
                 expect.objectContaining({
                     method: 'GET',
                     headers: expect.objectContaining({
                         Authorization: expect.stringContaining('Basic')
                     })
-                })
+                }),
+                // connect-timeout override is always supplied for CLI calls (SDK-6152)
+                expect.objectContaining({ connectTimeoutMs: expect.any(Number) })
             )
-            expect(global.fetch).toHaveBeenCalledWith(
+            expect(mockFetch).toHaveBeenCalledWith(
                 expect.stringContaining('param2=value2'),
+                expect.any(Object),
                 expect.any(Object)
             )
         })
 
         it('returns response from fetch', async () => {
             const mockResponse = { updated_cli_version: '2.0.0' }
-            global.fetch = vi.fn().mockResolvedValue({
+            mockFetch.mockResolvedValue({
                 json: vi.fn().mockResolvedValue(mockResponse)
             })
 
@@ -571,13 +584,55 @@ describe('CLIUtils', () => {
             expect(result).toEqual(mockResponse)
         })
 
-        it('handles errors from fetch', async () => {
+        it('handles errors from fetch after exhausting retries', async () => {
             const mockError = new Error('Network error')
-            global.fetch = vi.fn().mockRejectedValue(mockError)
+            mockFetch.mockRejectedValue(mockError)
 
             await expect(CLIUtils.requestToUpdateCLI({}, mockConfig))
                 .rejects
                 .toThrow('Network error')
+        })
+    })
+
+    describe('fetchWithRetry', () => {
+        beforeEach(() => {
+            vi.resetAllMocks()
+        })
+
+        it('passes the CLI connect-timeout override through to _fetch', async () => {
+            const res = { ok: true } as unknown as Response
+            mockFetch.mockResolvedValue(res)
+
+            const result = await CLIUtils.fetchWithRetry('https://example.com', { method: 'GET' }, 'test')
+
+            expect(result).toBe(res)
+            expect(mockFetch).toHaveBeenCalledTimes(1)
+            expect(mockFetch).toHaveBeenCalledWith(
+                'https://example.com',
+                { method: 'GET' },
+                expect.objectContaining({ connectTimeoutMs: expect.any(Number) })
+            )
+        })
+
+        it('retries on transient failure and then succeeds', async () => {
+            const res = { ok: true } as unknown as Response
+            mockFetch
+                .mockRejectedValueOnce(new Error('connect fail'))
+                .mockResolvedValueOnce(res)
+
+            const result = await CLIUtils.fetchWithRetry('https://example.com', {}, 'test')
+
+            expect(result).toBe(res)
+            expect(mockFetch).toHaveBeenCalledTimes(2)
+        })
+
+        it('throws the last error after exhausting all attempts', async () => {
+            mockFetch.mockRejectedValue(new Error('always fails'))
+
+            await expect(CLIUtils.fetchWithRetry('https://example.com', {}, 'test'))
+                .rejects
+                .toThrow('always fails')
+            expect(mockFetch).toHaveBeenCalledTimes(3)
         })
     })
 


### PR DESCRIPTION
## SDK-6152 — SDK CLI binary download times out after exactly 10s in containerised CI

### Problem
`@wdio/browserstack-service` v9 downloads the SDK CLI binary (and calls `update_cli`) via Node's **global `fetch` (undici)**. Undici hard-codes a **10s connection-establishment timeout** that is **not overridable via `AbortSignal`**. In constrained/containerised CI networks (the reported case: Kubernetes pods) the TLS/TCP handshake to the CDN / `api.browserstack.com` can legitimately take longer than 10s, so the download aborts with `UND_ERR_CONNECT_TIMEOUT` even though the endpoint is healthy. The failure was logged only at `debug`, so the run then **exited silently with no results**.

This matches the customer evidence exactly: a standalone `fetch()` probe of the *same* URL succeeded (free event loop / fast connect), while the service's internal download died at *exactly 10s*.

### Fix
- `fetchWrapper._fetch` now accepts a `connectTimeoutMs` option and routes the request through a **cached custom undici dispatcher** (`Agent` / `ProxyAgent`) with the configured connect timeout. The default (no-option) path is **unchanged** (still global `fetch`).
- `requestToUpdateCLI` and the binary download use it — default **60s**, overridable via `BROWSERSTACK_CLI_CONNECT_TIMEOUT_MS` — plus **retry-with-backoff** (3 attempts) on transient connection failures.
- CLI setup failures are surfaced at **`warn`** instead of `debug` so they're no longer silent.

### Why a custom dispatcher (and not global fetch + dispatcher)
Global fetch uses Node's *built-in* undici; passing an `Agent` from the *package* undici to it fails with `UND_ERR_INVALID_ARG` (version mismatch). Going through `undiciFetch` from the package — the same pattern the existing proxy branch already uses — is the consistent, safe choice.

### Verification
Against the **real modified `fetchWrapper.ts`**, using a local TCP server that accepts the socket but never completes TLS (deterministic stalled connect):

| Path | connect timeout | result |
|------|-----------------|--------|
| default (unchanged) | undici fixed 10s | `UND_ERR_CONNECT_TIMEOUT` @ **10,541ms** (reproduces the bug) |
| fixed | `connectTimeoutMs: 2000` | timeout @ **2,545ms** |
| fixed | `connectTimeoutMs: 6000` | timeout @ **6,502ms** |
| fixed, healthy CDN | 60s | connected @ **967ms** (no regression) |

→ the connect timeout now tracks the configured value instead of the hard 10s ceiling.

**Unit tests:** `packages/wdio-browserstack-service/tests/cli/cliUtils.test.ts` — **40/40 pass** (updated `requestToUpdateCLI` tests to the new `_fetch` boundary + 3 new `fetchWithRetry` tests). ESLint clean on changed files; `fetchWrapper.ts` type-checks clean.

### Note (server/CDN side, out of scope here)
The reported version trigger (binary `1.34.0` OK → `1.34.1/1.34.2` fail) is most plausibly CloudFront cache warmth / object-size changes around the new release pushing connect/transfer past the old 10s ceiling. This PR removes the client-side cliff; the CDN behaviour for new releases is worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
