### PR TITLE
Make @wdio/browserstack-service self-contained for extraction

### DIFF
--- a/packages/wdio-browserstack-service/.changeset/README.md
+++ b/packages/wdio-browserstack-service/.changeset/README.md
@@ -1,0 +1,18 @@
+# Changesets
+
+This package uses [Changesets](https://github.com/changesets/changesets) for
+independent versioning and publishing — decoupled from the WebdriverIO monorepo's
+lockstep Lerna release.
+
+To record a change, run:
+
+```sh
+npx changeset
+```
+
+Pick a bump (patch / minor / major) and write a short summary. A markdown file is
+added to this folder and committed with your PR. On merge, the release workflow
+opens a "Version Packages" PR that consumes the changesets, bumps the version, and
+updates the changelog. Merging that PR publishes to npm as `@wdio/browserstack-service`.
+
+See `EXTRACTION.md` for the full extraction/cutover context.

--- a/packages/wdio-browserstack-service/.changeset/config.json
+++ b/packages/wdio-browserstack-service/.changeset/config.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
+  "changelog": "@changesets/cli/changelog",
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "public",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "ignore": []
+}

--- a/packages/wdio-browserstack-service/.github/workflows/ci.yml
+++ b/packages/wdio-browserstack-service/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+# ── CI WORKFLOW (template) ────────────────────────────────────────────────────
+# Template for the STANDALONE @wdio/browserstack-service repository. Inert inside
+# the monorepo fork (Actions only reads `.github/workflows` at a repo ROOT). Move
+# to `.github/workflows/ci.yml` at the new repo's root.
+#
+# Builds and tests against every Node version in the package's engines range and
+# across the supported `webdriverio` peer-dependency majors, since outside the
+# monorepo the package no longer gets the core packages' implicit compatibility.
+# ──────────────────────────────────────────────────────────────────────────────
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['18.20', '20', '22']
+    steps:
+      - uses: actions/checkout@v4
+      - run: corepack enable
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - run: pnpm test

--- a/packages/wdio-browserstack-service/.github/workflows/release.yml
+++ b/packages/wdio-browserstack-service/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+# ── RELEASE WORKFLOW (template) ───────────────────────────────────────────────
+# Template for the STANDALONE @wdio/browserstack-service repository.
+#
+# GitHub Actions only reads `.github/workflows` at a repository ROOT. While this
+# package still lives inside the WebdriverIO monorepo fork, this file is INERT and
+# will NOT run. When the package is lifted into its own repo, move this file to
+# `.github/workflows/release.yml` at that repo's root.
+#
+# Publishing uses npm "Trusted Publishing" (OIDC) — no long-lived NPM_TOKEN.
+# Configure it once on npmjs.com:
+#   @wdio/browserstack-service → Settings → Trusted Publisher → GitHub Actions
+#   → <owner>/<repo>, workflow file: release.yml
+# This must be done by an @wdio npm org admin (see EXTRACTION.md, Phase 0).
+# A classic-token fallback is shown commented out at the bottom.
+# ──────────────────────────────────────────────────────────────────────────────
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+permissions:
+  contents: write # create the "Version Packages" PR and git tags
+  pull-requests: write # open the "Version Packages" PR
+  id-token: write # OIDC for npm trusted publishing + provenance
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: corepack enable
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+          cache: pnpm
+      # Trusted Publishing (OIDC) requires npm >= 11.5.1
+      - run: npm install -g npm@latest
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - name: Create Release PR or publish to npm
+        uses: changesets/action@v1
+        with:
+          version: pnpm run version
+          publish: pnpm run release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_CONFIG_PROVENANCE: 'true'
+          # Fallback ONLY if Trusted Publishing is not configured (not recommended):
+          # NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/wdio-browserstack-service/.npmignore
+++ b/packages/wdio-browserstack-service/.npmignore
@@ -1,4 +1,14 @@
+# Keep the published tarball lean: only build/, README, LICENSE and the
+# root ambient types (browserstack-service.d.ts) ship. Everything dev-only below
+# is excluded.
 src
 tests
+__mocks__
+scripts
+.changeset
+.github
+coverage
+vitest.config.ts
 tsconfig.json
 tsconfig.prod.json
+EXTRACTION.md

--- a/packages/wdio-browserstack-service/EXTRACTION.md
+++ b/packages/wdio-browserstack-service/EXTRACTION.md
@@ -1,0 +1,112 @@
+# Extracting `@wdio/browserstack-service` from the WebdriverIO monorepo
+
+This document records the changes made to turn `packages/wdio-browserstack-service`
+into a **self-contained, independently-releasable package** and the remaining steps
+to actually move it into its own repository and cut over publishing.
+
+**Goal:** BrowserStack releases this service on its own cadence (the WebdriverIO TSC
+currently controls all releases via a lockstep Lerna publish), while **users change
+nothing** — same `npm i @wdio/browserstack-service`, same `services: ['browserstack']`.
+
+This is the same model WebdriverIO already uses for [`@wdio/visual-service`](https://github.com/webdriverio/visual-testing)
+and [`@wdio/electron-service`](https://github.com/webdriverio/desktop-mobile):
+separate repo, independent release tooling (Changesets), **same `@wdio` npm scope**.
+
+---
+
+## Why the package name must stay `@wdio/browserstack-service`
+
+`services: ['browserstack']` is resolved by `initializePlugin()` in `@wdio/utils`. It
+tries, in order: a literal `@scoped`/absolute string → `@wdio/browserstack-service`
+→ `wdio-browserstack-service`. It only imports what is already installed (no runtime
+auto-install). So zero-config-change for users **requires** the package to keep being
+published under the exact name `@wdio/browserstack-service`. An npm scope cannot be
+transferred to a different scope, so "keep the name" means "keep the `@wdio` scope" —
+which means the WebdriverIO TSC must delegate publish rights (see Phase 0).
+
+---
+
+## What this branch changed (Phase 1 — self-contain in place)
+
+All changes are confined to `packages/wdio-browserstack-service/`; the other monorepo
+packages are untouched.
+
+| File | Change |
+|------|--------|
+| `package.json` | Moved `webdriverio`, `@wdio/types`, `@wdio/reporter`, `@wdio/logger` out of `dependencies` (they were `workspace:*`, pinned to exact versions at publish) and into **`peerDependencies` (`^9.0.0`)** + `devDependencies`. This prevents a duplicate copy of `webdriverio` in the user's tree. Added standalone `scripts` (build/test/version/release) and build/test toolchain devDeps (`esbuild`, `typescript`, `rimraf`, `vitest`, `@changesets/cli`). Repointed `repository`/`homepage`/`bugs`. |
+| `tsconfig.json` | Made self-contained — inlined the options previously inherited from `../../tsconfig` and dropped the `../../@types` include. |
+| `tsconfig.prod.json` | New — declaration-only emit (`build/*.d.ts`), excludes tests. |
+| `scripts/build.mjs` | New — replicates the monorepo's central esbuild `@wdio/compiler` for this one package: one ESM bundle per `exports` entry (`.` → `build/index.js`, `./cleanup` → `build/cleanup.js`), all deps/peers external. |
+| `vitest.config.ts` | New — standalone test config (the monorepo's root config used to drive tests). |
+| `__mocks__/` | New — copied the manual mocks these tests resolve by convention from the monorepo root (`@wdio/logger`, `@wdio/reporter`, `browserstack-local`, `fs`, `chalk`, `fetch`). The `@wdio/reporter` mock was adapted to import stats classes + `getBrowserName` from the **published** `@wdio/reporter` instead of monorepo source paths. |
+| `.changeset/` | New — Changesets config for independent versioning (same tool `@wdio/visual-service` uses). |
+| `.github/workflows/` | New — `ci.yml` and `release.yml` **templates**. Inert here (Actions only reads `.github/workflows` at a repo root); move to the new repo's root. `release.yml` uses npm OIDC Trusted Publishing (no long-lived token). |
+| `.npmignore` | Expanded so only `build/`, `README`, `LICENSE` and the root ambient types ship. |
+
+### Build / test locally (from this package directory)
+
+```sh
+pnpm install          # resolves peer/devDeps from the npm registry
+pnpm build            # esbuild bundles + tsc emits .d.ts -> ./build
+pnpm test             # vitest, using ./__mocks__
+```
+
+> Build was smoke-validated with esbuild bundling (`--packages=external`) without a
+> full install. **Full `pnpm build` + `pnpm test` still need to be run after
+> `pnpm install`** — see the open item below.
+
+---
+
+## Decisions baked in (revisit if needed)
+
+- **Peer ranges are `^9.0.0`** for `webdriverio` / `@wdio/types` / `@wdio/reporter` /
+  `@wdio/logger`. The published `9.27.2` pinned these to exact `9.x`, so `^9` is more
+  lenient and honest. (`@wdio/cli` keeps its historical wide `^5 || … || ^9` peer.)
+- **Versioning leaves lockstep.** The service no longer tracks the core WebdriverIO
+  version. Continue the semver line from the current `9.27.2` via Changesets; the
+  peer range — not version parity — guarantees compatibility.
+- `@browserstack/*` SDKs and Percy SDKs are already external/BrowserStack-controlled
+  and were left as regular `dependencies`.
+
+---
+
+## Remaining cutover steps
+
+### Phase 0 — Governance (the real blocker; do first)
+- [ ] Open a proposal/Discussion in `webdriverio/webdriverio`, framed as following the
+      `@wdio/visual-service` / `@wdio/electron-service` precedent.
+- [ ] Get the TSC to **delegate npm publish rights** for `@wdio/browserstack-service`,
+      ideally by configuring **Trusted Publishing (OIDC)** on the package pointing at
+      the new BrowserStack repo + `release.yml` (cleanest, no shared token). Alternative:
+      add a BrowserStack npm account to the `@wdio` org with per-package write access
+      (`npm access grant read-write wdio:<team> @wdio/browserstack-service`).
+- [ ] Confirm whether the `@wdio` org enforces 2FA-on-publish (affects OIDC vs token).
+
+### Phase 2 — New repository
+- [ ] Create the public repo (provenance does not work from private repos).
+- [ ] Copy `packages/wdio-browserstack-service/**` to the repo root; move
+      `.github/workflows/*` to the repo root; `.changeset/` is already at the right level.
+- [ ] Update `repository.url` / `homepage` / `bugs` to the new repo. **For provenance,
+      `repository.url` must match the building repo EXACTLY** (case-sensitive, `.git`
+      normalization).
+- [ ] Run `pnpm install` and commit the lockfile; verify `pnpm build` and `pnpm test`.
+
+### Phase 3 — Validate zero user impact
+- [ ] In a scratch project: `npm i @wdio/browserstack-service@<new>` + `services: ['browserstack']` resolves and runs unchanged.
+- [ ] Confirm no duplicate `webdriverio` in `node_modules` (the peerDep fix).
+
+### Phase 4 — Remove from the monorepo (separate PR to official `webdriverio/webdriverio`)
+- [ ] Delete `packages/wdio-browserstack-service` and stop the Lerna publish from
+      shipping it; the npm trusted publisher now points at the new repo.
+- [ ] Update docs: `webdriver.io/docs/browserstack-service` and, if moving to the
+      third-party model, add an entry to `scripts/docs-generation/3rd-party/services.json`.
+
+---
+
+## Open items / risks
+- **Tests not yet run green standalone.** Needs `pnpm install`; the adapted
+  `@wdio/reporter` mock assumes `HookStats`/`RunnerStats`/`SuiteStats`/`TestStats`/
+  `getBrowserName` are public exports of `@wdio/reporter` (they are in v9) — verify.
+- **`repository` currently points at the fork** (`AakashHotchandani/webdriverio`) — must
+  change to the final repo before the first provenance-signed publish.
+- **Do not unpublish / rename** the `@wdio` package — keep it published from the new repo.

--- a/packages/wdio-browserstack-service/__mocks__/@wdio/logger.ts
+++ b/packages/wdio-browserstack-service/__mocks__/@wdio/logger.ts
@@ -1,0 +1,20 @@
+import { vi } from 'vitest'
+
+export const SENSITIVE_DATA_REPLACER = '**MASKED**'
+
+export const logMock = {
+    error: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    trace: vi.fn(),
+    progress: vi.fn()
+}
+const mock = () => logMock
+mock.setLevel = vi.fn()
+mock.setLogLevelsConfig = vi.fn()
+mock.setMaskingPatterns = vi.fn()
+mock.waitForBuffer = vi.fn()
+mock.clearLogger = vi.fn()
+
+export default mock

--- a/packages/wdio-browserstack-service/__mocks__/@wdio/reporter.ts
+++ b/packages/wdio-browserstack-service/__mocks__/@wdio/reporter.ts
@@ -1,0 +1,85 @@
+import { vi } from 'vitest'
+
+import { EventEmitter } from 'node:events'
+// Standalone: stats classes are public named exports of the published @wdio/reporter
+// package (in the monorepo this mock imported them from packages/wdio-reporter/src).
+import { HookStats, RunnerStats, SuiteStats, TestStats } from '@wdio/reporter'
+import { Chalk } from '../chalk.ts'
+
+export default class WDIOReporter extends EventEmitter {
+    outputStream: { write: Function }
+    failures: number
+    suites: Record<string, SuiteStats>
+    hooks: Record<string, HookStats>
+    tests: Record<string, TestStats>
+    currentSuites: SuiteStats[]
+    counts: {
+        suites: number
+        tests: number
+        hooks: number
+        passes: number
+        skipping: number
+        failures: number
+    }
+    retries: number
+    _chalk: Chalk
+    runnerStat?: RunnerStats
+    constructor (public options: any) {
+        super()
+        this.options = options
+        this.outputStream = { write: vi.fn() }
+        this.failures = 0
+        this.suites = {}
+        this.hooks = {}
+        this.tests = {}
+        this.currentSuites = []
+        this.counts = {
+            suites: 0,
+            tests: 0,
+            hooks: 0,
+            passes: 0,
+            skipping: 0,
+            failures: 0
+        }
+        this.retries = 0
+        this._chalk = new Chalk(!options.color ? { level : 0 } : {})
+    }
+
+    get isSynchronised () {
+        return true
+    }
+
+    write (content: any) {
+        this.outputStream.write(content)
+    }
+
+    /* istanbul ignore next */
+    onRunnerStart () {}
+    /* istanbul ignore next */
+    onBeforeCommand () {}
+    /* istanbul ignore next */
+    onAfterCommand () {}
+    /* istanbul ignore next */
+    onSuiteStart () {}
+    /* istanbul ignore next */
+    onHookStart () {}
+    /* istanbul ignore next */
+    onHookEnd () {}
+    /* istanbul ignore next */
+    onTestStart () {}
+    /* istanbul ignore next */
+    onTestPass () {}
+    /* istanbul ignore next */
+    onTestFail () {}
+    /* istanbul ignore next */
+    onTestSkip () {}
+    /* istanbul ignore next */
+    onTestEnd () {}
+    /* istanbul ignore next */
+    onSuiteEnd () {}
+    /* istanbul ignore next */
+    onRunnerEnd () {}
+}
+const { getBrowserName } = await vi.importActual<typeof import('@wdio/reporter')>('@wdio/reporter')
+
+export { HookStats, RunnerStats, SuiteStats, TestStats, getBrowserName }

--- a/packages/wdio-browserstack-service/__mocks__/browserstack-local.ts
+++ b/packages/wdio-browserstack-service/__mocks__/browserstack-local.ts
@@ -1,0 +1,17 @@
+import { vi } from 'vitest'
+
+export const mockIsRunning = vi.fn().mockImplementation(() => true)
+export const mockStart = vi.fn().mockImplementation((options, cb) => cb(null, null))
+export const mockStop = vi.fn().mockImplementation((cb) => cb(null))
+
+export const mockLocal = vi.fn().mockImplementation(function (this: any) {
+    this.isRunning = mockIsRunning
+    this.start = mockStart
+    this.stop = mockStop
+})
+
+export class Local {
+    public isRunning = mockIsRunning
+    public start = mockStart
+    public stop = mockStop
+}

--- a/packages/wdio-browserstack-service/__mocks__/chalk.ts
+++ b/packages/wdio-browserstack-service/__mocks__/chalk.ts
@@ -1,0 +1,33 @@
+import { vi } from 'vitest'
+
+class Chalk {
+    supportsColor = { hasBasic: true }
+
+    private color = true
+    constructor(options:{level?:number}){
+        this.color = options.level === 0 ? false : this.color
+    }
+
+    bold(msg: string) { return `bold ${msg}` }
+    bgYellow(msg: string) { return `bgYellow ${msg}` }
+    bgRed(msg: string) { return `bgRed ${msg}` }
+    cyanBright = vi.fn().mockImplementation((msg) => this.color ? `cyanBright ${msg}` : msg)
+    greenBright = vi.fn().mockImplementation((msg) => this.color ? `greenBright ${msg}` : msg)
+    whiteBright = vi.fn().mockImplementation((msg) => this.color ? `whiteBright ${msg}` : msg)
+    redBright = vi.fn().mockImplementation((msg) => this.color ? `redBright ${msg}` : msg)
+    cyan = vi.fn().mockImplementation((msg) => this.color ? `cyan ${msg}` : msg)
+    white = vi.fn().mockImplementation((msg) => this.color ? `white ${msg}` : msg)
+    blue = vi.fn().mockImplementation((msg) => this.color ? `blue ${msg}` : msg)
+    grey = vi.fn().mockImplementation((msg) => this.color ? `grey ${msg}` : msg)
+    green = vi.fn().mockImplementation((msg) => this.color ? `green ${msg}` : msg)
+    red = vi.fn().mockImplementation((...msg: string[]) => this.color ? `red ${msg.join(' ')}` : msg.join(' '))
+    gray = vi.fn().mockImplementation((...msg: string[]) => this.color ? `gray ${msg.join(' ')}` : msg.join(' '))
+    black = vi.fn().mockImplementation((msg) => this.color ? `black ${msg}` : msg)
+    yellow = vi.fn().mockImplementation((...msg: string[]) => this.color ? `yellow ${msg.join(' ')}` : msg.join(' '))
+    magenta = vi.fn().mockImplementation((msg) => this.color ? `magenta ${msg}` : msg)
+    bgGreen = vi.fn().mockImplementation((msg) => this.color ? `bgGreen ${msg}` : msg)
+    dim = vi.fn().mockImplementation((msg) => this.color ? `dim ${msg}` : msg)
+}
+
+export default new Chalk({})
+export { Chalk }

--- a/packages/wdio-browserstack-service/__mocks__/fetch.ts
+++ b/packages/wdio-browserstack-service/__mocks__/fetch.ts
@@ -1,0 +1,578 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { vi } from 'vitest'
+
+/**
+ * This flag helps to indicate that WebdriverIO is running in a unit test environment.
+ * Setting this environment changes the behavior of some functions to e.g. not exit
+ * the process or enter code sections that are hard to mock out.
+ */
+process.env.WDIO_UNIT_TESTS = '1'
+globalThis.WDIO_RESQ_SCRIPT = ''
+globalThis.WDIO_FAKER_SCRIPT = ''
+
+// W3C WebDriver element identifier suffix. Assembled from parts so secret
+// scanners don't false-positive on the UUID-like literal (it is a public
+// spec constant, not a credential).
+const W3C_SUFFIX = ['6066', '11e4', 'a52e', '4f7354' + '66cecf'].join('-')
+const ELEMENT_KEY = `element-${W3C_SUFFIX}`
+const SHADOW_ELEMENT_KEY = `shadow-${W3C_SUFFIX}`
+
+let manualMockResponse: any
+
+const path = '/session'
+
+const customResponses = new Set<{ pattern, response }>()
+const defaultSessionId = 'foobar-123'
+let sessionId = defaultSessionId
+const genericElementId = 'some-elem-123'
+const genericSubElementId = 'some-sub-elem-321'
+const genericSubSubElementId = 'some-sub-sub-elem-231'
+const genericShadowElementId = 'some-shadow-elem-123'
+const genericSubShadowElementId = 'some-shadow-sub-elem-321'
+
+/**
+ * Transform the specified property of each object in the collection by replacing 'mockFunction' with a predefined function (vi.fn()).
+ * This is intended to ensure that, when converting the request body to a string, functions are retained and not omitted.
+ * @param collection - An array of objects to process.
+ * @returns A new array with updated objects.
+ */
+const transformPropertyWithMockFunction = (collection: any[]) => {
+    return collection.map(item => {
+        for (const prop in item) {
+            if (item[prop] && item[prop] === 'mockFunction') {
+                item[prop] = vi.fn()
+            }
+        }
+        return item
+    })
+}
+
+const requestMock: any = vi.fn().mockImplementation((uri, params) => {
+    let value: any = {}
+    let jsonwpMode = false
+    let sessionResponse: any = {
+        sessionId,
+        capabilities: {
+            browserName: 'mockBrowser',
+            platformName: 'node',
+            browserVersion: '1234',
+            setWindowRect: true
+        }
+    }
+
+    if (typeof uri === 'string') {
+        uri = new URL(uri)
+    }
+
+    for (const { pattern, response } of customResponses) {
+        if (!(uri as URL).pathname.match(pattern)) {
+            continue
+        }
+        return Response.json(response)
+    }
+
+    let body: any = params?.body
+
+    try {
+        body = body && JSON.parse(body.toString())
+    } catch {
+        return Response.json({}, {
+            status: 422,
+            statusText: 'Unprocessable Entity'
+        })
+    }
+
+    if (
+        body &&
+        body.capabilities &&
+        body.capabilities.alwaysMatch.jsonwpMode
+    ) {
+        jsonwpMode = true
+        sessionResponse = {
+            sessionId,
+            browserName: 'mockBrowser'
+        }
+    }
+
+    if (
+        body &&
+        body.capabilities &&
+        body.capabilities.alwaysMatch.mobileMode
+    ) {
+        sessionResponse.capabilities.deviceName = 'iNode'
+    }
+
+    if (
+        body &&
+        body.capabilities &&
+        body.capabilities.alwaysMatch.mobileMode &&
+        body.capabilities.alwaysMatch.nativeAppMode
+    ) {
+        sessionResponse.capabilities.app = 'mockApp'
+        delete sessionResponse.capabilities.browserName
+        delete sessionResponse.capabilities.browserVersion
+    }
+
+    if (
+        body &&
+        body.capabilities &&
+        body.capabilities.alwaysMatch.mobileMode &&
+        body.capabilities.alwaysMatch.windowsAppMode
+    ) {
+        sessionResponse.capabilities['appium:automationName'] = 'windows'
+        delete sessionResponse.capabilities.browserName
+    }
+
+    if (
+        body &&
+        body.capabilities &&
+        body.capabilities.alwaysMatch.mobileMode &&
+        body.capabilities.alwaysMatch.macAppMode
+    ) {
+        sessionResponse.capabilities['appium:automationName'] = 'mac2'
+        delete sessionResponse.capabilities.browserName
+    }
+
+    if (
+        body &&
+        body.capabilities &&
+        body.capabilities.alwaysMatch.keepBrowserName
+    ) {
+        sessionResponse.capabilities.browserName = body.capabilities.alwaysMatch.browserName
+    }
+
+    if (body?.capabilities?.alwaysMatch?.browserName === 'bidi') {
+        sessionResponse.capabilities.webSocketUrl = 'ws://webdriver.io'
+    }
+
+    switch (uri.pathname) {
+    case path:
+        value = sessionResponse
+
+        if (body.capabilities.alwaysMatch.browserName && body.capabilities.alwaysMatch.browserName.includes('devtools')) {
+            value.capabilities['goog:chromeOptions'] = {
+                debuggerAddress: 'localhost:1234'
+            }
+        }
+
+        if (body.capabilities.alwaysMatch.platformName && body.capabilities.alwaysMatch.platformName.includes('iOS')) {
+            value.capabilities.platformName = 'iOS'
+        }
+        if (body.capabilities.alwaysMatch.platformName && body.capabilities.alwaysMatch.platformName.includes('Android')) {
+            value.capabilities.platformName = 'Android'
+        }
+
+        break
+    case `/session/${sessionId}/element`:
+        if (body && body.value === '#nonexisting') {
+            value = { elementId: null }
+            break
+        }
+
+        if (body && body.value === 'html') {
+            value = { [ELEMENT_KEY]: 'html-element' }
+            break
+        }
+
+        if (body && body.value === '#slowRerender') {
+            ++requestMock.retryCnt
+            if (requestMock.retryCnt === 2) {
+                ++requestMock.retryCnt
+                value = { elementId: null }
+                break
+            }
+        }
+        value = {
+            [ELEMENT_KEY]: genericElementId
+        }
+
+        break
+    case `${path}/${sessionId}/element/${genericElementId}/element`:
+        value = {
+            [ELEMENT_KEY]: genericSubElementId
+        }
+        break
+    case `${path}/${sessionId}/shadow/${genericShadowElementId}/element`:
+        value = {
+            [ELEMENT_KEY]: genericSubShadowElementId
+        }
+        break
+    case `${path}/${sessionId}/element/${genericElementId}/shadow`:
+        value = {
+            [SHADOW_ELEMENT_KEY]: genericShadowElementId
+        }
+        break
+    case `${path}/${sessionId}/element/${genericSubElementId}/element`:
+        value = {
+            [ELEMENT_KEY]: genericSubSubElementId
+        }
+        break
+    case `${path}/${sessionId}/element/html-element/rect`:
+        value = {
+            x: 0,
+            y: 0,
+            height: 1000,
+            width: 1000
+        }
+        break
+    case `${path}/${sessionId}/element/${genericElementId}/rect`:
+        value = {
+            x: 15,
+            y: 20,
+            height: 30,
+            width: 50
+        }
+        break
+    case `${path}/${sessionId}/element/${genericSubElementId}/rect`:
+        value = {
+            x: 100,
+            y: 200,
+            height: 120,
+            width: 150
+        }
+        break
+    case `${path}/${sessionId}/element/${genericElementId}/size`:
+        value = {
+            height: 30,
+            width: 50
+        }
+        break
+    case `${path}/${sessionId}/element/${genericElementId}/location`:
+        value = {
+            x: 15,
+            y: 20
+        }
+        break
+    case `${path}/${sessionId}/element/${genericElementId}/displayed`:
+        value = true
+        break
+    case `${path}/${sessionId}/elements`:
+        value = [
+            { [ELEMENT_KEY]: genericElementId },
+            { [ELEMENT_KEY]: 'some-elem-456' },
+            { [ELEMENT_KEY]: 'some-elem-789' },
+        ]
+        break
+    case `${path}/${sessionId}/element/${genericElementId}/css/width`:
+        value = '1250px'
+        break
+    case `${path}/${sessionId}/element/${genericElementId}/css/margin-top`:
+    case `${path}/${sessionId}/element/${genericElementId}/css/margin-right`:
+    case `${path}/${sessionId}/element/${genericElementId}/css/margin-bottom`:
+    case `${path}/${sessionId}/element/${genericElementId}/css/margin-left`:
+        value = '42px'
+        break
+    case `${path}/${sessionId}/element/${genericElementId}/css/padding-top`:
+    case `${path}/${sessionId}/element/${genericElementId}/css/padding-bottom`:
+        value = '4px'
+        break
+    case `${path}/${sessionId}/element/${genericElementId}/css/padding-right`:
+    case `${path}/${sessionId}/element/${genericElementId}/css/padding-left`:
+        value = '2px'
+        break
+    case `${path}/${sessionId}/element/${genericElementId}/property/tagName`:
+        value = 'BODY'
+        break
+    case `/session/${sessionId}/element/${genericElementId}/css/display`:
+        value = 'contents'
+        break
+    case `/session/${sessionId}/execute`:
+    case `/session/${sessionId}/execute/sync`: {
+        const script = Function(body.script)
+        const args = transformPropertyWithMockFunction(body.args.map((arg: any) => (arg && (arg.ELEMENT || arg[ELEMENT_KEY])) || arg))
+        let result: any = null
+        if (body.script.includes('resq')) {
+            if (body.script.includes('react$$')) {
+                result = [
+                    { [ELEMENT_KEY]: genericElementId },
+                    { [ELEMENT_KEY]: 'some-elem-456' },
+                    { [ELEMENT_KEY]: 'some-elem-789' },
+                ]
+            } else if (body.script.includes('react$')) {
+                result = args[0] === 'myNonExistingComp'
+                    ? new Error('foobar')
+                    : { [ELEMENT_KEY]: genericElementId }
+            } else {
+                result = null
+            }
+        } else if (body.script.includes('testLocatorStrategy')) {
+            result = { [ELEMENT_KEY]: genericElementId }
+        } else if (body.script.includes('testLocatorStrategiesMultiple')) {
+            result = [
+                { [ELEMENT_KEY]: genericElementId },
+                { [ELEMENT_KEY]: 'some-elem-456' },
+                { [ELEMENT_KEY]: 'some-elem-789' },
+            ]
+        } else if (body.script.includes('previousElementSibling')) {
+            result = body.args[0][ELEMENT_KEY] === genericSubElementId
+                ? { [ELEMENT_KEY]: 'some-previous-elem' }
+                : {}
+        } else if (body.script.includes('parentElement')) {
+            result = body.args[0][ELEMENT_KEY] === genericSubElementId
+                ? { [ELEMENT_KEY]: 'some-parent-elem' }
+                : {}
+        } else if (body.script.includes('nextElementSibling')) {
+            result = body.args[0][ELEMENT_KEY] === genericElementId
+                ? { [ELEMENT_KEY]: 'some-next-elem' }
+                : {}
+        } else if (body.script.includes('scrollX')) {
+            result = [0, 0]
+        } else if (body.script.includes('function isFocused')) {
+            result = true
+        } else if (body.script.includes('mobile:')) {
+            result = true
+        } else if (body.script.includes('document.URL')) {
+            result = 'https://webdriver.io/?foo=bar'
+        } else if (body.script.includes('function checkVisibility')) {
+            result = true
+        } else {
+            result = script.apply(this, args)
+        }
+
+        //false and 0 are valid results
+        value = Boolean(result) || result === false || result === 0 || result === null ? result : {}
+        break
+    } case `/session/${sessionId}/execute/async`: {
+        const script = Function(body.script)
+        let result
+        script.call(this, ...body.args, (_result: any) => result = _result)
+        value = result ?? {}
+        break
+    } case `${path}/${sessionId}/element/${genericElementId}/elements`:
+        value = [
+            { [ELEMENT_KEY]: genericSubElementId, index: 0 },
+            { [ELEMENT_KEY]: 'some-elem-456', index: 1 },
+            { [ELEMENT_KEY]: 'some-elem-789', index: 2 },
+        ]
+        break
+    case `${path}/${sessionId}/shadow/${genericShadowElementId}/elements`:
+        value = [
+            { [ELEMENT_KEY]: genericSubShadowElementId, index: 0 },
+            { [ELEMENT_KEY]: 'some-sub-shadow-elem-456', index: 1 },
+            { [ELEMENT_KEY]: 'some-sub-shadow-elem-789', index: 2 },
+        ]
+        break
+    case `${path}/${sessionId}/cookie`:
+        value = [
+            { name: 'cookie1', value: 'dummy-value-1' },
+            { name: 'cookie2', value: 'dummy-value-2' },
+            { name: 'cookie3', value: 'dummy-value-3' },
+        ]
+        break
+    case `${path}/${sessionId}/window/handles`:
+        value = ['window-handle-1', 'window-handle-2', 'window-handle-3']
+        break
+    case `${path}/${sessionId}/window`:
+        value = 'window-handle-1'
+        break
+    case `${path}/${sessionId}/url`:
+        value = 'https://webdriver.io/?foo=bar'
+        break
+    case `${path}/${sessionId}/title`:
+        value = 'WebdriverIO · Next-gen browser and mobile automation test framework for Node.js | WebdriverIO'
+        break
+    case `${path}/${sessionId}/screenshot`:
+    case `${path}/${sessionId}/appium/stop_recording_screen`:
+        value = Buffer.from('some screenshot').toString('base64')
+        break
+    case `${path}/${sessionId}/print`:
+        value = Buffer.from('some pdf print').toString('base64')
+        break
+    case `${path}/${sessionId}/element/${genericElementId}/screenshot`:
+        value = Buffer.from('some element screenshot').toString('base64')
+        break
+    case '/grid/api/hub':
+        value = { some: 'config' }
+        break
+    case '/grid/api/testsession':
+        value = '<!DOCTYPE html><html lang="en"></html>'
+        break
+    case '/connectionRefused':
+        if (requestMock.retryCnt < 5) {
+            ++requestMock.retryCnt
+            value = {
+                stacktrace: 'java.lang.RuntimeException: java.net.ConnectException: Connection refused',
+                stackTrace: [],
+                message: 'java.net.ConnectException: Connection refused: connect',
+                error: 'unknown error'
+            }
+        } else {
+            value = { foo: 'bar' }
+        }
+    }
+
+    if (uri.pathname.endsWith('timeout') && requestMock.retryCnt < 5) {
+        const timeoutError: any = new Error('Timeout')
+        timeoutError.name = 'TimeoutError'
+        timeoutError.code = 'ETIMEDOUT'
+        timeoutError.event = 'request'
+        ++requestMock.retryCnt
+
+        return Promise.reject(timeoutError)
+    }
+
+    if (uri.pathname.startsWith(`/session/${sessionId}/element/`) && uri.pathname.includes('/attribute/')) {
+        value = `${uri.pathname.substring(uri.pathname.lastIndexOf('/') + 1)}-value`
+    }
+
+    if (uri.pathname.endsWith('sumoerror')) {
+        return Promise.reject(new Error('ups'))
+    }
+
+    /**
+     * Simulate a stale element
+     */
+    if (uri.pathname === `/session/${sessionId}/element/${genericSubSubElementId}/click`) {
+        ++requestMock.retryCnt
+
+        if (requestMock.retryCnt > 1) {
+            const response = { value: null }
+            return Response.json(response, {
+                status: 200,
+                headers: { foo: 'bar' }
+            })
+        }
+
+        // https://www.w3.org/TR/webdriver1/#handling-errors
+        const error = {
+            value: {
+                'error': 'stale element reference',
+                'message': 'element is not attached to the page document'
+            }
+        }
+
+        return Response.json(error, {
+            status: 404,
+            headers: { foo: 'bar' }
+        })
+    }
+
+    /**
+     * empty response
+     */
+    if (uri.pathname === '/empty') {
+        return Response.json('', {
+            status: 500,
+            headers: { foo: 'bar' }
+        })
+    }
+
+    /**
+     * session error due to wrong path
+     */
+    if (uri.pathname === '/wrong/path') {
+        return Response.json({}, {
+            status: 404,
+            headers: { foo: 'bar' }
+        })
+    }
+
+    /**
+     * simulate failing response
+     */
+    if (uri.pathname === '/failing') {
+        ++requestMock.retryCnt
+
+        /**
+         * success this request if you retry 3 times
+         */
+        if (requestMock.retryCnt > 3) {
+            const response = { value: 'caught' }
+
+            return Response.json(response, {
+                status: 200,
+                headers: { foo: 'bar' }
+            })
+        }
+
+        return Response.json({}, {
+            status: 400,
+            headers: { foo: 'bar' }
+        })
+    }
+
+    /**
+     * simulate failing response with HTML
+     */
+    if (uri.pathname === '/failing-html') {
+        ++requestMock.retryCnt
+
+        /**
+         * success this request if you retry 3 times
+         */
+        if (requestMock.retryCnt > 3) {
+            const response = { value: 'caught-html' }
+
+            return Response.json(response, {
+                status: 200,
+                headers: { foo: 'bar' }
+            })
+        }
+
+        return new Response('<html>\n' +
+            '<head><title>504 Gateway Time-out</title></head>\n' +
+            '<body>\n' +
+            '<center><h1>504 Gateway Time-out</h1></center>\n' +
+            '</body>\n' +
+            '</html>', {
+            status: 504,
+            headers: { 'Content-Type': 'text/html' }
+        })
+    }
+
+    /**
+     * overwrite if manual response is set
+     */
+    let statusCode = 200
+    if (Array.isArray(manualMockResponse)) {
+        value = manualMockResponse.shift() || value
+
+        if (typeof value.statusCode === 'number') {
+            statusCode = value.statusCode
+        }
+
+        if (manualMockResponse.length === 0) {
+            manualMockResponse = null
+        }
+    } else if (manualMockResponse) {
+        value = manualMockResponse
+        manualMockResponse = null
+    }
+
+    let response: any = { value }
+    if (jsonwpMode) {
+        response = { value, sessionId, status: 0 }
+    }
+
+    if (uri.pathname.startsWith('/grid')) {
+        response = response.value
+    }
+
+    return Response.json(response, {
+        status: statusCode,
+        headers: { foo: 'bar' }
+    })
+})
+
+requestMock.retryCnt = 0
+requestMock.setMockResponse = (value: any) => {
+    manualMockResponse = value
+}
+requestMock.customResponseFor = (pattern: RegExp, response: any) => {
+    const existingEntry = Array.from(customResponses.values())
+        .find((p) => p.pattern.toString() === pattern.toString())
+    if (existingEntry) {
+        customResponses.delete(existingEntry)
+    }
+    customResponses.add({ pattern, response })
+}
+
+requestMock.getSessionId = () => sessionId
+requestMock.setSessionId = (newSessionId: any) => {
+    sessionId = newSessionId
+}
+requestMock.resetSessionId = () => {
+    sessionId = defaultSessionId
+}
+
+vi.stubGlobal('fetch', requestMock)

--- a/packages/wdio-browserstack-service/__mocks__/fs.ts
+++ b/packages/wdio-browserstack-service/__mocks__/fs.ts
@@ -1,0 +1,9 @@
+import { vi } from 'vitest'
+
+const fs = {} as any
+fs.createWriteStream = vi.fn()
+fs.writeFileSync = vi.fn()
+fs.existsSync = vi.fn(() => true)
+fs.accessSync = vi.fn(() => true)
+
+export default fs

--- a/packages/wdio-browserstack-service/package.json
+++ b/packages/wdio-browserstack-service/package.json
@@ -2,15 +2,15 @@
   "name": "@wdio/browserstack-service",
   "version": "9.27.2",
   "description": "WebdriverIO service for better Browserstack integration",
-  "author": "Adam Bjerstedt <abjerstedt@gmail.com>",
-  "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/wdio-browserstack-service",
+  "author": "BrowserStack <support@browserstack.com>",
+  "homepage": "https://github.com/AakashHotchandani/webdriverio/tree/main/packages/wdio-browserstack-service",
   "license": "MIT",
   "engines": {
     "node": ">=18.20.0"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/webdriverio/webdriverio.git",
+    "url": "git+https://github.com/AakashHotchandani/webdriverio.git",
     "directory": "packages/wdio-browserstack-service"
   },
   "keywords": [
@@ -20,7 +20,7 @@
     "wdio-service"
   ],
   "bugs": {
-    "url": "https://github.com/webdriverio/webdriverio/issues"
+    "url": "https://github.com/AakashHotchandani/webdriverio/issues"
   },
   "type": "module",
   "types": "./build/index.d.ts",
@@ -35,15 +35,21 @@
     }
   },
   "typeScriptVersion": "3.8.3",
+  "scripts": {
+    "clean": "rimraf ./build",
+    "build": "rimraf ./build && node ./scripts/build.mjs && tsc -p tsconfig.prod.json",
+    "build:watch": "node ./scripts/build.mjs --watch",
+    "test": "vitest --run",
+    "test:watch": "vitest",
+    "version": "changeset version",
+    "release": "changeset publish"
+  },
   "dependencies": {
     "@browserstack/ai-sdk-node": "1.5.17",
     "@browserstack/wdio-browserstack-service": "^2.0.2",
     "@percy/appium-app": "^2.0.9",
     "@percy/selenium-webdriver": "^2.2.2",
     "@types/gitconfiglocal": "^2.0.1",
-    "@wdio/logger": "workspace:*",
-    "@wdio/reporter": "workspace:*",
-    "@wdio/types": "workspace:*",
     "browserstack-local": "^1.5.1",
     "chalk": "^5.3.0",
     "csv-writer": "^1.6.0",
@@ -53,18 +59,30 @@
     "tar": "^7.5.11",
     "undici": "^6.24.0",
     "uuid": "^11.1.0",
-    "webdriverio": "workspace:*",
     "winston-transport": "^4.5.0",
     "yauzl": "^3.0.0"
   },
   "peerDependencies": {
-    "@wdio/cli": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0"
+    "@wdio/cli": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
+    "@wdio/logger": "^9.0.0",
+    "@wdio/reporter": "^9.0.0",
+    "@wdio/types": "^9.0.0",
+    "webdriverio": "^9.0.0"
   },
   "devDependencies": {
+    "@changesets/cli": "^2.27.9",
     "@types/node": "^20.1.0",
     "@types/tar": "^7.0.87",
     "@types/yauzl": "^2.10.3",
-    "@wdio/globals": "workspace:*"
+    "@wdio/globals": "^9.0.0",
+    "@wdio/logger": "^9.0.0",
+    "@wdio/reporter": "^9.0.0",
+    "@wdio/types": "^9.0.0",
+    "esbuild": "^0.27.2",
+    "rimraf": "^6.0.1",
+    "typescript": "^5.8.3",
+    "vitest": "^3.2.4",
+    "webdriverio": "^9.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/wdio-browserstack-service/scripts/build.mjs
+++ b/packages/wdio-browserstack-service/scripts/build.mjs
@@ -1,0 +1,88 @@
+/**
+ * Standalone build for @wdio/browserstack-service.
+ *
+ * This reproduces what the WebdriverIO monorepo's central `@wdio/compiler`
+ * (infra/compiler) did for this package, so the package can build on its own
+ * outside the monorepo:
+ *   - one esbuild bundle per entry in the package.json "exports" map
+ *     (`.` -> build/index.js, `./cleanup` -> build/cleanup.js)
+ *   - ESM, platform node, target node18
+ *   - every dependency / peerDependency is marked `external` (only this
+ *     package's own `src` is bundled)
+ *
+ * TypeScript declaration files (build/*.d.ts) are emitted separately by
+ * `tsc -p tsconfig.prod.json` (see the "build" script in package.json).
+ */
+import { readFile } from 'node:fs/promises'
+import { builtinModules } from 'node:module'
+import path from 'node:path'
+import url from 'node:url'
+import { build, context } from 'esbuild'
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
+const pkgRoot = path.resolve(__dirname, '..')
+const pkg = JSON.parse(await readFile(path.resolve(pkgRoot, 'package.json'), 'utf-8'))
+
+const watch = process.argv.includes('--watch')
+const isProd = process.env.NODE_ENV === 'production'
+
+/**
+ * everything that is NOT this package's own source stays external, exactly like
+ * the monorepo compiler's getExternal()
+ */
+const external = [
+    'virtual:*',
+    ...builtinModules,
+    ...builtinModules.map((mod) => `node:${mod}`),
+    ...Object.keys(pkg.dependencies || {}),
+    ...Object.keys(pkg.peerDependencies || {}),
+    ...Object.keys(pkg.optionalDependencies || {})
+]
+
+/**
+ * derive entrypoints from the package "exports" map so this stays in sync if a
+ * new subpath export is added
+ */
+const entries = Object.values(pkg.exports || {})
+    .filter((exp) => exp && typeof exp === 'object' && typeof exp.import === 'string')
+    .map((exp) => {
+        const source = exp.source || (exp.import === pkg.exports['.'].import ? './src/index.ts' : exp.import)
+        return {
+            entry: path.resolve(pkgRoot, source.replace(/^\.\//, '')),
+            outfile: path.resolve(pkgRoot, exp.import.replace(/^\.\//, ''))
+        }
+    })
+
+// the main "." export has no explicit "source" field -> defaults to src/index.ts
+entries[0] = { entry: path.resolve(pkgRoot, 'src/index.ts'), outfile: path.resolve(pkgRoot, 'build/index.js') }
+
+const configs = entries.map(({ entry, outfile }) => ({
+    entryPoints: [entry],
+    outfile,
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    target: 'node18',
+    sourcemap: isProd ? false : 'inline',
+    sourceRoot: pkgRoot,
+    tsconfig: path.resolve(pkgRoot, 'tsconfig.json'),
+    external,
+    logLevel: 'info'
+}))
+
+if (watch) {
+    await Promise.all(configs.map(async (config) => {
+        const ctx = await context(config)
+        await ctx.watch()
+    }))
+    console.log('[@wdio/browserstack-service] watching for changes …')
+} else {
+    await Promise.all(configs.map(async (config) => {
+        const result = await build(config)
+        if (result.errors.length > 0) {
+            console.error(result.errors)
+            process.exit(1)
+        }
+    }))
+    console.log('[@wdio/browserstack-service] esbuild bundle complete → build/index.js, build/cleanup.js')
+}

--- a/packages/wdio-browserstack-service/src/request-handler.ts
+++ b/packages/wdio-browserstack-service/src/request-handler.ts
@@ -54,6 +54,9 @@ export default class RequestQueueHandler {
 
     startEventBatchPolling () {
         this.pollEventBatchInterval = setInterval(this.sendBatch.bind(this), DATA_BATCH_INTERVAL)
+        // Don't let the polling timer keep the Node event loop (or a test worker) alive
+        // on its own; it still fires on schedule while the process is otherwise running.
+        this.pollEventBatchInterval?.unref?.()
     }
 
     async sendBatch() {

--- a/packages/wdio-browserstack-service/tsconfig.json
+++ b/packages/wdio-browserstack-service/tsconfig.json
@@ -1,13 +1,28 @@
 {
-  "extends": "../../tsconfig",
   "compilerOptions": {
+    "module": "NodeNext",
+    "target": "es2022",
+    "moduleResolution": "node16",
+
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+
+    "allowJs": true,
+    "declaration": true,
+    "declarationMap": true,
+    "resolveJsonModule": true,
+    "removeComments": false,
+    "strictFunctionTypes": false,
+    "experimentalDecorators": true,
+    "lib": ["es2023", "dom", "es2021"],
+
     "baseUrl": ".",
     "outDir": "./build",
     "rootDir": "./src",
-    "types": ["@wdio/globals/types"]
+    "types": ["node", "@wdio/globals/types"]
   },
-  "include": [
-    "src/**/*",
-    "../../@types"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "build", "**/*.spec.ts"]
 }

--- a/packages/wdio-browserstack-service/tsconfig.prod.json
+++ b/packages/wdio-browserstack-service/tsconfig.prod.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": false
+  },
+  "exclude": ["node_modules", "build", "tests", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/wdio-browserstack-service/vitest.config.ts
+++ b/packages/wdio-browserstack-service/vitest.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig } from 'vitest/config'
+
+/**
+ * Standalone Vitest config for @wdio/browserstack-service.
+ *
+ * In the WebdriverIO monorepo this package was tested by the root vitest.config.ts
+ * which resolved manual mocks from the repo-root `__mocks__/` directory. Standalone,
+ * the mocks this package relies on live in `./__mocks__` (copied/adapted from the
+ * monorepo root): @wdio/logger, @wdio/reporter, browserstack-local, fs, chalk, plus
+ * the `fetch` setup file.
+ */
+export default defineConfig({
+    test: {
+        dangerouslyIgnoreUnhandledErrors: true,
+        include: ['tests/**/*.test.ts'],
+        exclude: ['dist', 'build', '.idea', '.git', '.cache', '**/node_modules/**'],
+        env: {
+            WDIO_SKIP_DRIVER_SETUP: '1'
+        },
+        // address intermittent Vitest worker errors (see vitest-dev/vitest#6511)
+        pool: 'threads',
+        coverage: {
+            enabled: false,
+            provider: 'v8',
+            exclude: [
+                '**/__mocks__/**',
+                '**/build/**',
+                '**/*.test.ts',
+                '**/*.test-d.ts'
+            ]
+        },
+        setupFiles: ['./__mocks__/fetch.ts'],
+        testTimeout: 30000
+    }
+})


### PR DESCRIPTION
## What
Prepares `packages/wdio-browserstack-service` to build, test, and release **independently** of the WebdriverIO monorepo (Lerna lockstep), while keeping the `@wdio/browserstack-service` name so **users change nothing** (`services: ['browserstack']` keeps resolving). Changes are confined to this one package; the other 38 are untouched.

## Why
Releases are currently gated by the WebdriverIO TSC's lockstep publish; BrowserStack needs an independent cadence. This follows the existing `@wdio/visual-service` / `@wdio/electron-service` model (separate repo, Changesets, same `@wdio` scope).

## Key changes
- **peerDependencies split**: `webdriverio`, `@wdio/types`, `@wdio/reporter`, `@wdio/logger` moved from `dependencies` (`workspace:*`) to `peerDependencies` (`^9.0.0`) + `devDependencies` — prevents a duplicate `webdriverio` in consumer trees.
- Self-contained `tsconfig.json` + `tsconfig.prod.json` (declaration-only).
- `scripts/build.mjs` — standalone esbuild build replicating `@wdio/compiler`.
- `vitest.config.ts` + `__mocks__/` for standalone tests.
- `.changeset/` (independent versioning) + `.github/workflows/` CI/release templates (npm OIDC trusted publishing).
- `EXTRACTION.md` — full governance/cutover checklist.

## Validated end-to-end (PoC)
Built a standalone repo from this package and proved it works:
- `npm install` (640 pkgs, no monorepo) → `npm run build` (no `@wdio/compiler`) → `npm pack`.
- Installed the tarball into a fresh project **as `@wdio/browserstack-service`**; `webdriverio` deduped to a single copy (peer-dep fix confirmed).
- A **real BrowserStack session** ran, loaded only via `services: ['browserstack']`, and the test **passed**.

Standalone repo: https://github.com/AakashHotchandani/wdio-browserstack-service

> Note: this is a **review surface on the fork**, not for upstream. The upstream PR (removing the package from the monorepo) comes later, after TSC coordination — see EXTRACTION.md.