### PR TITLE
feat(browserstack-service): stamp hook_run_uuid on App A11y scans fired inside hooks [APPA11Y-5542]

### DIFF
--- a/packages/wdio-browserstack-service/src/accessibility-handler.ts
+++ b/packages/wdio-browserstack-service/src/accessibility-handler.ts
@@ -444,7 +444,7 @@ class _AccessibilityHandler {
         }
     }
 
-    async afterHook (_test?: Frameworks.Test, _context?: unknown, _result?: Frameworks.TestResult, _hookRunUuid?: string | null) {
+    async afterHook () {
         // Hook finished: subsequent (test-body) scans must not be stamped as hook scans.
         this._currentHookRunUuid = null
     }

--- a/packages/wdio-browserstack-service/src/accessibility-handler.ts
+++ b/packages/wdio-browserstack-service/src/accessibility-handler.ts
@@ -68,7 +68,9 @@ import {
     validateCapsWithAppA11y,
     getAppA11yResults,
     isFalse,
-    setBrowserstackAnnotation
+    setBrowserstackAnnotation,
+    getHookType,
+    frameworkSupportsHook
 } from './util.js'
 import accessibilityScripts from './scripts/accessibility-scripts.js'
 import PerformanceTester from './instrumentation/performance/performance-tester.js'
@@ -88,6 +90,8 @@ class _AccessibilityHandler {
     private _autoScanning: boolean = true
     private _testIdentifier: string | null = null
     private _testMetadata: TestMetadata = {}
+    /* Set while a supported hook is executing; scans fired in this window are stamped with it. */
+    private _currentHookRunUuid: string | null = null
     private static _a11yScanSessionMap: A11yScanSessionMap = {}
     private _sessionId: string | null = null
     private listener = Listener.getInstance()
@@ -397,6 +401,54 @@ class _AccessibilityHandler {
         }
     }
 
+    /**
+     * Hook scans. A driver command executed inside a test hook (before/after,
+     * beforeEach/afterEach, cucumber hooks) should fire an accessibility scan and carry
+     * the hook's run UUID so the backend (SeleniumHub appAllyHandler -> app-accessibility)
+     * can reconcile it onto the wrapping test case instead of collapsing into a NULL row.
+     * `hookRunUuid` is the SAME uuid the SDK reports to TestHub as HookRunStarted
+     * (InsightsHandler.getCurrentHook), i.e. the hook's BTCER uuid.
+     * Additive: when hookRunUuid is absent, in-test scan behaviour is unchanged.
+     */
+    async beforeHook (test: Frameworks.Test | undefined, context: unknown, hookRunUuid?: string | null) {
+        try {
+            if (!this._accessibility || !this.shouldRunTestHooks(this._browser, this._accessibility)) {
+                return
+            }
+            // Only for frameworks/hooks that actually support hooks (mocha before/after/beforeEach/afterEach, cucumber).
+            if (!frameworkSupportsHook('before', this._framework)) {
+                return
+            }
+
+            // Scans fired until the matching afterHook belong to this hook.
+            this._currentHookRunUuid = hookRunUuid || null
+
+            // Enable scanning for the hook window (mocha). Per-test hooks honour the wrapped
+            // test's include/exclude scope; suite-level hooks fall back to autoScanning. The
+            // cucumber scan gate is owned by beforeScenario; we only add hook stamping there.
+            if (this._framework === 'mocha' && this._sessionId) {
+                let shouldScan = this._autoScanning
+                const hookType = (test && typeof test.title === 'string') ? getHookType(test.title) : 'unknown'
+                const wrappedTest = (context as { currentTest?: Frameworks.Test } | undefined)?.currentTest
+                if ((hookType === 'BEFORE_EACH' || hookType === 'AFTER_EACH') && wrappedTest) {
+                    let suiteTitle: unknown = wrappedTest.parent
+                    if (suiteTitle && typeof suiteTitle === 'object') {
+                        suiteTitle = (suiteTitle as { title?: string }).title
+                    }
+                    shouldScan = this._autoScanning && shouldScanTestForAccessibility(suiteTitle as string | undefined, wrappedTest.title, this._accessibilityOptions)
+                }
+                AccessibilityHandler._a11yScanSessionMap[this._sessionId] = shouldScan
+            }
+        } catch (error) {
+            BStackLogger.error(`Exception in accessibility automation beforeHook: ${error}`)
+        }
+    }
+
+    async afterHook (_test?: Frameworks.Test, _context?: unknown, _result?: Frameworks.TestResult, _hookRunUuid?: string | null) {
+        // Hook finished: subsequent (test-body) scans must not be stamped as hook scans.
+        this._currentHookRunUuid = null
+    }
+
     /*
      * private methods
      */
@@ -410,7 +462,7 @@ class _AccessibilityHandler {
                 )
         ) {
             BStackLogger.debug(`Performing scan for ${command.class} ${command.name}`)
-            await performA11yScan(this.isAppAutomate, this._browser, true, true, command.name)
+            await performA11yScan(this.isAppAutomate, this._browser, true, true, command.name, this._currentHookRunUuid)
         }
         return origFunction(...args)
     }

--- a/packages/wdio-browserstack-service/src/insights-handler.ts
+++ b/packages/wdio-browserstack-service/src/insights-handler.ts
@@ -184,6 +184,12 @@ class _InsightsHandler {
         }
     }
 
+    /* Exposes the current hook run so other handlers (e.g. AccessibilityHandler) can
+       stamp the same hook UUID we report to TestHub as HookRunStarted. */
+    getCurrentHook(): CurrentRunInfo {
+        return this._currentHook
+    }
+
     async sendScenarioObjectSkipped(scenario: Scenario, feature: Feature, uri: string) {
         const testMetaData: TestMeta = {
             uuid: uuidv4(),

--- a/packages/wdio-browserstack-service/src/service.ts
+++ b/packages/wdio-browserstack-service/src/service.ts
@@ -340,6 +340,9 @@ export default class BrowserstackService implements Services.ServiceInstance {
             this._currentTest = test as Frameworks.Test // not update currentTest when this is called for cucumber step
         }
         await this._insightsHandler?.beforeHook(test, context)
+        // Reuse the exact hook UUID InsightsHandler just reported to TestHub (HookRunStarted)
+        // so a11y hook scans carry a hook_run_uuid that matches the hook's BTCER row.
+        await this._accessibilityHandler?.beforeHook(test as Frameworks.Test, context, this._insightsHandler?.getCurrentHook()?.uuid)
     }
 
     @PerformanceTester.Measure(PERFORMANCE_SDK_EVENTS.EVENTS.SDK_HOOK, { hookType: 'afterHook' })
@@ -355,6 +358,7 @@ export default class BrowserstackService implements Services.ServiceInstance {
             }
         }
         await this._insightsHandler?.afterHook(test, result)
+        await this._accessibilityHandler?.afterHook(test as Frameworks.Test, context, result, this._insightsHandler?.getCurrentHook()?.uuid)
     }
 
     @PerformanceTester.Measure(PERFORMANCE_SDK_EVENTS.EVENTS.SDK_HOOK, { hookType: 'beforeTest' })

--- a/packages/wdio-browserstack-service/src/service.ts
+++ b/packages/wdio-browserstack-service/src/service.ts
@@ -358,7 +358,7 @@ export default class BrowserstackService implements Services.ServiceInstance {
             }
         }
         await this._insightsHandler?.afterHook(test, result)
-        await this._accessibilityHandler?.afterHook(test as Frameworks.Test, context, result, this._insightsHandler?.getCurrentHook()?.uuid)
+        await this._accessibilityHandler?.afterHook()
     }
 
     @PerformanceTester.Measure(PERFORMANCE_SDK_EVENTS.EVENTS.SDK_HOOK, { hookType: 'beforeTest' })

--- a/packages/wdio-browserstack-service/src/util.ts
+++ b/packages/wdio-browserstack-service/src/util.ts
@@ -566,9 +566,12 @@ export const formatString = (template: (string | null), ...values: (string | nul
     })
 }
 
-export const _getParamsForAppAccessibility = ( commandName?: string ): { thTestRunUuid: any, thBuildUuid: any, thJwtToken: any, authHeader: any, scanTimestamp: Number, method: string | undefined  } => {
+export const _getParamsForAppAccessibility = ( commandName?: string, hookRunUuid?: string | null ): { thTestRunUuid: any, thHookRunUuid: any, thBuildUuid: any, thJwtToken: any, authHeader: any, scanTimestamp: Number, method: string | undefined  } => {
     return {
         'thTestRunUuid': process.env.TEST_ANALYTICS_ID,
+        // Present only when the scan fires inside a hook. Dropped by JSON.stringify when undefined,
+        // so in-test scans are byte-for-byte unchanged. SeleniumHub relays this as `hook_run_uuid`.
+        'thHookRunUuid': hookRunUuid || undefined,
         'thBuildUuid': process.env.BROWSERSTACK_TESTHUB_UUID,
         'thJwtToken': process.env.BROWSERSTACK_TESTHUB_JWT,
         'authHeader': process.env.BSTACK_A11Y_JWT,
@@ -577,7 +580,7 @@ export const _getParamsForAppAccessibility = ( commandName?: string ): { thTestR
     }
 }
 
-export const performA11yScan = async (isAppAutomate: boolean, browser: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser, isBrowserStackSession?: boolean, isAccessibility?: boolean | string, commandName?: string) : Promise<{ [key: string]: any; } | undefined> => {
+export const performA11yScan = async (isAppAutomate: boolean, browser: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser, isBrowserStackSession?: boolean, isAccessibility?: boolean | string, commandName?: string, hookRunUuid?: string | null) : Promise<{ [key: string]: any; } | undefined> => {
     return await PerformanceTester.measureWrapper(PERFORMANCE_SDK_EVENTS.A11Y_EVENTS.PERFORM_SCAN, async () => {
 
         if (!isAccessibilityAutomationSession(isAccessibility)) {
@@ -587,7 +590,7 @@ export const performA11yScan = async (isAppAutomate: boolean, browser: Webdriver
 
         try {
             if (isAppAccessibilityAutomationSession(isAccessibility, isAppAutomate)) {
-                const results: unknown = await (browser as WebdriverIO.Browser).execute(formatString(AccessibilityScripts.performScan, JSON.stringify(_getParamsForAppAccessibility(commandName))) as string, {})
+                const results: unknown = await (browser as WebdriverIO.Browser).execute(formatString(AccessibilityScripts.performScan, JSON.stringify(_getParamsForAppAccessibility(commandName, hookRunUuid))) as string, {})
                 BStackLogger.debug(util.format(results as string))
                 return ( results as { [key: string]: any; } | undefined )
             }

--- a/packages/wdio-browserstack-service/tests/accessibility-handler.test.ts
+++ b/packages/wdio-browserstack-service/tests/accessibility-handler.test.ts
@@ -391,6 +391,43 @@ describe('afterScenario', () => {
     })
 })
 
+describe('beforeHook / afterHook (hook scans)', () => {
+    beforeEach(() => {
+        accessibilityHandler = new AccessibilityHandler(browser, caps, options, false, config, 'mocha', true, false, accessibilityOpts)
+        vi.spyOn(utils, 'isBrowserstackSession').mockReturnValue(true)
+        vi.spyOn(utils, 'isAccessibilityAutomationSession').mockReturnValue(true)
+        accessibilityHandler['_sessionId'] = 'session123'
+    })
+
+    it('stamps the hook run uuid inside a supported mocha per-test hook', async () => {
+        vi.spyOn(utils, 'shouldScanTestForAccessibility').mockReturnValue(true)
+        await accessibilityHandler.beforeHook(
+            { title: '"before each" hook', parent: 'suite' } as any,
+            { currentTest: { parent: 'suite', title: 'test' } },
+            'hook-uuid-1'
+        )
+        expect(accessibilityHandler['_currentHookRunUuid']).toBe('hook-uuid-1')
+    })
+
+    it('clears the hook run uuid on afterHook so test-body scans are not stamped', async () => {
+        await accessibilityHandler.beforeHook(
+            { title: '"after each" hook', parent: 'suite' } as any,
+            { currentTest: { parent: 'suite', title: 'test' } },
+            'hook-uuid-2'
+        )
+        expect(accessibilityHandler['_currentHookRunUuid']).toBe('hook-uuid-2')
+        await accessibilityHandler.afterHook({ title: '"after each" hook' } as any, {}, { passed: true } as any, 'hook-uuid-2')
+        expect(accessibilityHandler['_currentHookRunUuid']).toBeNull()
+    })
+
+    it('does not stamp when the framework does not support hooks', async () => {
+        const jasmineHandler = new AccessibilityHandler(browser, caps, options, false, config, 'jasmine', true, false, accessibilityOpts)
+        jasmineHandler['_sessionId'] = 'session123'
+        await jasmineHandler.beforeHook({ title: '"before each" hook' } as any, {}, 'hook-uuid-3')
+        expect(jasmineHandler['_currentHookRunUuid']).toBeNull()
+    })
+})
+
 describe('beforeTest', () => {
     let executeAsyncSpy: any
     let executeSpy: any


### PR DESCRIPTION
Port of the App A11y hook-scan change to the webdriverio monorepo copy of `@wdio/browserstack-service` (v8 base). Mirrors browserstack/wdio-browserstack-service#48.

## What
The SDK stamps the hook's run UUID (`thHookRunUuid`) on App A11y scans fired inside a supported hook (`before`/`after`, `beforeEach`/`afterEach`). SeleniumHub `appAllyHandler` (PR #14162) relays it as `hook_run_uuid`; app-accessibility reconciles the scan onto the wrapping test. **Additive** — no field ⇒ in-test scan behaviour unchanged.

## Changes
- `util.ts` — `_getParamsForAppAccessibility` / `performA11yScan` thread `thHookRunUuid`.
- `insights-handler.ts` — `getCurrentHook()` exposes the HookRunStarted uuid (= hook BTCER uuid).
- `accessibility-handler.ts` — `beforeHook`/`afterHook` set `_currentHookRunUuid` + enable the mocha hook scan gate; `commandWrapper` passes it to `performA11yScan`.
- `service.ts` — wire `accessibilityHandler.beforeHook/afterHook`.
- tests — hook-scan stamp/clear + unsupported-framework no-op.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)